### PR TITLE
Add back/src/shared -> front/src symlink to npm scripts

### DIFF
--- a/.github/workflows/front-ci.yml
+++ b/.github/workflows/front-ci.yml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Copy shared folder from backend
-        run: cp -r back/src/shared front/src
       - name: Install npm dependencies
         run: cd front && npm ci
       - name: Run tests

--- a/front/package.json
+++ b/front/package.json
@@ -1,11 +1,11 @@
 {
   "version": "0.0.0",
   "scripts": {
-    "test": "jest",
-    "dev": "npm run copy-shared && vite",
-    "build": "npm run copy-shared && tsc && vite build",
+    "test": "npm run symlink-shared && jest",
+    "dev": "npm run symlink-shared && vite",
+    "build": "npm run symlink-shared && tsc && vite build",
     "serve": "vite preview",
-    "copy-shared": "cp -r ../back/src/shared ./src/"
+    "symlink-shared": "ln -fs ../../back/src/shared ./src/"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.6.0",


### PR DESCRIPTION
- todo list exemple project
- add front and back github actions workflows
- [back] add typecheck script and use it in CI
- fix broken test in JsonTodoRepository.integration.test
- better error message + fix date creation
- [back] remove test data from versionning
- Update back/src/domain/todos/entities/TodoEntity.ts
- add symlink to make front tests pass
